### PR TITLE
Add simple reset password page, using our own API

### DIFF
--- a/.github/workflows/docker-pu.yml
+++ b/.github/workflows/docker-pu.yml
@@ -50,6 +50,15 @@ jobs:
         id: should_force
         run: echo "should_force=${{ steps.found_paths.outputs.workflow == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}" >> "$GITHUB_OUTPUT"
 
+      - name: Set API url
+        id: set_api_url
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ startsWith(github.ref, 'refs/tags/') }}" ]]; then
+            echo "PUBLIC_API_URL=https://api.tech.pixelunion.eu" >> web/.env
+          else
+            echo "PUBLIC_API_URL=https://api.nonprd.tech.pixelunion.eu" >> web/.env
+          fi
+
   retag_server:
     name: Re-Tag Server
     needs: pre-job
@@ -96,9 +105,9 @@ jobs:
       context: .
       dockerfile: server/Dockerfile
       dockerhub-push: ${{ github.event_name == 'release' }}
-      build-args: |
+      build-args: |-
         DEVICE=cpu
-
+        PUBLIC_API_URL=${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 'https://api.tech.pixelunion.eu' || 'https://api.nonprd.tech.pixelunion.eu' }}
   success-check-server:
     name: Docker Build & Push Server Success
     needs: [server, retag_server]

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,23 @@
+# Changes Log
+
+At PixelUnion, we value openness and open source. This document serves as a record of the changes we have made to the Immich codebase and the features we have contributed back to the community, or are planning to contribute back.
+
+## Changes Made
+
+- [X] Replaced Immich trademark logos
+- [X] Added billing link to user drop down menu
+- [X] Added simple password reset page that uses PixelUnion api
+
+# Updating fork
+
+1. Add Immich main repo as upstream
+```git remote add upstream git@github.com:immich-app/immich.git```
+2. Fetch upstream
+```git getch upstream```
+3. Merge new version
+```git merge upstream/v1.134.0```
+4. Fix potential conflicts
+5. Test changes above for correct functioning.
+6. Tag commit with immich version and PixelUnion version like:
+```v1.133.5-pu1``` later version should increment the pu tag
+7. Push the tag

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -21,6 +21,7 @@ declare namespace App {
 declare module '$env/static/public' {
   export const PUBLIC_IMMICH_PAY_HOST: string;
   export const PUBLIC_IMMICH_BUY_HOST: string;
+  export const PUBLIC_API_URL: string;
 }
 
 interface Element {

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -151,7 +151,7 @@
 
         <p class="text-center mt-4">
           <a
-            href="https://pixelunion.eu/support/forgot-password/"
+            href="/auth/reset-password"
             target="_blank"
             class="text-blue-500 hover:underline"
           >

--- a/web/src/routes/auth/reset-password/+page.svelte
+++ b/web/src/routes/auth/reset-password/+page.svelte
@@ -6,6 +6,7 @@
   import { Alert, Button, Field, HelperText, Input, Stack, Text } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
+ import { PUBLIC_API_URL } from '$env/static/public';
 
   interface Props {
     data: PageData;
@@ -23,7 +24,7 @@
     submitting = true;
     error429 = false;
     try {
-      const response = await fetch( import.meta.env.VITE_API_URL + '/api/auth/password-reset', {
+      const response = await fetch( PUBLIC_API_URL + '/api/auth/password-reset', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/routes/auth/reset-password/+page.svelte
+++ b/web/src/routes/auth/reset-password/+page.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import AuthPageLayout from '$lib/components/layouts/AuthPageLayout.svelte';
+  import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { user } from '$lib/stores/user.store';
+  import { updateMyUser } from '@immich/sdk';
+  import { Alert, Button, Field, HelperText, Input, Stack, Text } from '@immich/ui';
+  import { t } from 'svelte-i18n';
+  import type { PageData } from './$types';
+
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+
+  let email = $state('');
+  let success = $state(false);
+  let submitting = $state(false);
+  let error429 = $state(false);
+
+  const onSubmit = async (event: Event) => {
+    event.preventDefault();
+    submitting = true;
+    error429 = false;
+    try {
+      const response = await fetch( import.meta.env.VITE_API_URL + '/api/auth/password-reset', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({'email': email }),
+      });
+      if (response.status === 429) {
+        error429 = true;
+        submitting = false;
+        return;
+      }
+      if (!response.ok) {
+        // Handle error (optional: show error to user)
+        console.error('Failed to send reset email');
+        submitting = false;
+      } else {
+        // Handle success (optional: show success to user)
+        success = true;
+      }
+    } catch (error) {
+      console.error('Error sending reset email', error);
+      submitting = false;
+    }
+  };
+</script>
+
+<AuthPageLayout title={data.meta.title}>
+  <form onsubmit={onSubmit} class="flex flex-col gap-4">
+    {#if !success}
+    <Alert color="primary" size="small" class="mb-2">
+      <Stack gap={4}>
+        <Text>Use this page to reset your admin password. Only administrators of this PixelUnion instance are allowed to reset their password. If you are a non-admin user, please ask your administrator to reset the password for you.</Text>
+      </Stack>
+    </Alert>
+    {/if}
+
+    {#if success}
+      <Alert color="success" size="small">
+        <Stack gap={4}>
+          <Text>If the email exists and belongs to an administrator, an email will have been sent. Click the link in the email to reset your password.</Text>
+        </Stack>
+      </Alert>
+    {/if}
+
+    {#if error429}
+      <Alert color="danger" size="small" class="mb-2">
+        <Stack gap={4}>
+          <Text>Too many requests. Please wait a few minutes before trying again.</Text>
+        </Stack>
+      </Alert>
+    {/if}
+
+    {#if !success}
+    <Field label={$t('admin_email')} required>
+      <Input bind:value={email} type="email" autocomplete="email" />
+    </Field>
+
+
+    <Button class="mt-2" type="submit" size="large" shape="round" fullWidth disabled={submitting}>
+      {submitting ? 'Sending...' : 'Request email to reset password'}
+    </Button>
+    {/if}
+  </form>
+</AuthPageLayout>

--- a/web/src/routes/auth/reset-password/+page.ts
+++ b/web/src/routes/auth/reset-password/+page.ts
@@ -1,0 +1,12 @@
+import { getFormatter } from '$lib/utils/i18n';
+import type { PageLoad } from './$types';
+
+export const load = (async ({ url }) => {
+  const $t = await getFormatter();
+
+  return {
+    meta: {
+      title: $t('change_password'),
+    },
+  };
+}) satisfies PageLoad;

--- a/web/src/routes/auth/reset-password/token/+page.svelte
+++ b/web/src/routes/auth/reset-password/token/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import AuthPageLayout from '$lib/components/layouts/AuthPageLayout.svelte';
+  import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { user } from '$lib/stores/user.store';
+  import { updateMyUser } from '@immich/sdk';
+  import { Alert, Button, Field, HelperText, PasswordInput, Stack, Text } from '@immich/ui';
+  import { t } from 'svelte-i18n';
+  import type { PageData } from './$types';
+
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+
+  let success = $state(false);
+  let submitting = $state(false);
+  let error429 = $state(false);
+  let errorReset = $state(false);
+
+  let password = $state('');
+  let passwordConfirm = $state('');
+  const valid = $derived(password === passwordConfirm && passwordConfirm.length > 0);
+  const errorMessage = $derived(passwordConfirm.length === 0 || valid ? '' : $t('password_does_not_match'));
+
+  const onSubmit = async (event: Event) => {
+    event.preventDefault();
+    if (!valid) {
+      return;
+    }
+    submitting = true;
+    error429 = false;
+    errorReset = false;
+    try {
+      const response = await fetch(
+        import.meta.env.VITE_API_URL + '/api/auth/password-reset',
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            token: data.token,
+            timestamp: data.timestamp,
+            password: password
+          }),
+        }
+      );
+      if (response.status === 429) {
+        error429 = true;
+        submitting = false;
+        return;
+      }
+      if (!response.ok) {
+        errorReset = true;
+        submitting = false;
+      } else {
+        success = true;
+      }
+    } catch (error) {
+      errorReset = true;
+      submitting = false;
+    }
+  };
+</script>
+
+<AuthPageLayout title={data.meta.title}>
+  {#if data.isValid}
+    {#if success}
+      <Alert color="success" size="small" class="mb-2">
+        <Stack gap={4}>
+          <Text>{$t('password_reset_success') || 'Your password has been reset successfully.'}</Text>
+        </Stack>
+      </Alert>
+      <a href="/" class="text-primary underline">Go to homepage</a>
+    {:else}
+      <form onsubmit={onSubmit} class="flex flex-col gap-4">
+        <Alert color="primary" size="small" class="mb-2">
+          <Stack gap={4}>
+            <Text>{$t('change_password_description')}</Text>
+          </Stack>
+        </Alert>
+
+        <Field label={$t('new_password')} required>
+          <PasswordInput bind:value={password} autocomplete="new-password" />
+        </Field>
+
+        <Field label={$t('confirm_password')} required>
+          <PasswordInput bind:value={passwordConfirm} autocomplete="new-password" />
+          <HelperText color="danger">{errorMessage}</HelperText>
+        </Field>
+
+        {#if error429}
+          <Alert color="danger" size="small" class="mb-2">
+            <Stack gap={4}>
+              <Text>Too many requests. Please wait a few minutes before trying again.</Text>
+            </Stack>
+          </Alert>
+        {/if}
+        {#if errorReset}
+          <Alert color="danger" size="small" class="mb-2">
+            <Stack gap={4}>
+              <Text>Failed to reset password. Please check your link or try again later.</Text>
+            </Stack>
+          </Alert>
+        {/if}
+
+        <Button class="mt-2" type="submit" size="large" shape="round" fullWidth disabled={!valid || submitting}
+          >{$t('to_change_password')}</Button
+        >
+      </form>
+    {/if}
+  {:else}
+    <Alert color="danger" size="small" class="mb-2">
+      <Stack gap={4}>
+        <Text>The password reset request is not valid or has expired. Please request a new password reset link.</Text>
+      </Stack>
+    </Alert>
+  {/if}
+</AuthPageLayout>

--- a/web/src/routes/auth/reset-password/token/+page.svelte
+++ b/web/src/routes/auth/reset-password/token/+page.svelte
@@ -6,6 +6,7 @@
   import { Alert, Button, Field, HelperText, PasswordInput, Stack, Text } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
+  import { PUBLIC_API_URL } from '$env/static/public';
 
   interface Props {
     data: PageData;
@@ -33,7 +34,7 @@
     errorReset = false;
     try {
       const response = await fetch(
-        import.meta.env.VITE_API_URL + '/api/auth/password-reset',
+        PUBLIC_API_URL + '/api/auth/password-reset',
         {
           method: 'PUT',
           headers: {

--- a/web/src/routes/auth/reset-password/token/+page.ts
+++ b/web/src/routes/auth/reset-password/token/+page.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_API_URL } from '$env/static/public';
 import { getFormatter } from '$lib/utils/i18n';
 import type { PageLoad } from './$types';
 
@@ -10,7 +11,7 @@ export const load = (async ({ url, fetch }) => {
   if (token && timestamp) {
     try {
       const res = await fetch(
-        import.meta.env.VITE_API_URL + '/api/auth/password-reset/validate-token',
+        PUBLIC_API_URL + '/api/auth/password-reset/validate-token',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/web/src/routes/auth/reset-password/token/+page.ts
+++ b/web/src/routes/auth/reset-password/token/+page.ts
@@ -1,0 +1,34 @@
+import { getFormatter } from '$lib/utils/i18n';
+import type { PageLoad } from './$types';
+
+export const load = (async ({ url, fetch }) => {
+  const $t = await getFormatter();
+  const token = url.searchParams.get('token');
+  const timestamp = url.searchParams.get('timestamp');
+  let isValid = false;
+
+  if (token && timestamp) {
+    try {
+      const res = await fetch(
+        import.meta.env.VITE_API_URL + '/api/auth/password-reset/validate-token',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, timestamp }),
+        }
+      );
+      isValid = res.status === 200;
+    } catch (e) {
+      isValid = false;
+    }
+  }
+
+  return {
+    meta: {
+      title: $t('change_password'),
+    },
+    token,
+    timestamp,
+    isValid,
+  };
+}) satisfies PageLoad;

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -6,6 +6,7 @@ dotenv.config();
 
 process.env.PUBLIC_IMMICH_BUY_HOST = process.env.PUBLIC_IMMICH_BUY_HOST || 'https://buy.immich.app';
 process.env.PUBLIC_IMMICH_PAY_HOST = process.env.PUBLIC_IMMICH_PAY_HOST || 'https://pay.futo.org';
+process.env.PUBLIC_API_URL = process.env.PUBLIC_API_URL || 'https://api.tech.pixelunion.eu';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
This pull request introduces a new password reset flow for administrators, including a dedicated reset password page and updates to the login page. The changes streamline the password reset process and provide user feedback for success or error scenarios.

### Password Reset Flow Enhancements:

* **Login Page Update**: Updated the "Forgot Password" link in `web/src/routes/auth/login/+page.svelte` to point to the new password reset page (`/auth/reset-password`) instead of an external URL.
* **New Password Reset Page**: Added `web/src/routes/auth/reset-password/+page.svelte`, implementing the password reset functionality. The page includes a form for administrators to request a password reset email, with feedback for success, error, and rate-limiting scenarios.

### Localization Support:

* **Page Metadata**: Added `web/src/routes/auth/reset-password/+page.ts` to set the page title dynamically based on localization, using the `getFormatter` utility.## Description
